### PR TITLE
Update for learn.microsoft.com in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
 
   "name": "FFS MSDN in English",
-  "description": "This will change the localisation of MSDN, azure.microsoft, support.microsoft and/or docs.microsoft pages to English (en-us).",
-  "version": "2.2.0",
+  "description": "This will change the localisation of MSDN, azure.microsoft, support.microsoft and/or learn.microsoft pages to English (en-us).",
+  "version": "2.3.0",
   "applications": {
     "gecko": {
       "id": "{b3abf5b1-5525-4838-b84f-c152a772f3a8}",
@@ -24,10 +24,8 @@
     "webRequest",
     "webRequestBlocking",
     "storage",
-    "*://msdn.microsoft.com/*", 
-    "*://*.msdn.microsoft.com/*",
-    "*://docs.microsoft.com/*",
-    "*://*.docs.microsoft.com/*",
+    "*://learn.microsoft.com/*", 
+    "*://*.learn.microsoft.com/*",
     "*://support.microsoft.com/*",
     "*://*.support.microsoft.com/*",
     "*://azure.microsoft.com/*",

--- a/popup.html
+++ b/popup.html
@@ -12,28 +12,21 @@
             </div>
             <ul class="list-group">
                 <li class="list-group-item">
-                    docs.microsoft
+                    learn.microsoft.com
                     <div class="material-switch pull-right">
-                        <input id="docs" name="docsOption" type="checkbox"/>
-                        <label for="docs" class="label-success"/>
+                        <input id="learn" name="learnOption" type="checkbox"/>
+                        <label for="learn" class="label-success"/>
                     </div>
                 </li>
                 <li class="list-group-item">
-                    MSDN
-                    <div class="material-switch pull-right">
-                        <input id="msdn" name="msdnOption" type="checkbox"/>
-                        <label for="msdn" class="label-success"/>
-                    </div>
-                </li>
-                <li class="list-group-item">
-                    support.microsoft
+                    support.microsoft.com
                     <div class="material-switch pull-right">
                         <input id="support" name="supportOption" type="checkbox"/>
                         <label for="support" class="label-success"/>
                     </div>
                 </li>
                 <li class="list-group-item">
-                    azure.microsoft
+                    azure.microsoft.com
                     <div class="material-switch pull-right">
                         <input id="azure" name="azureOption" type="checkbox"/>
                         <label for="azure" class="label-success"/>

--- a/popup.js
+++ b/popup.js
@@ -1,23 +1,15 @@
 "use strict";
 // Fix HTML
 $(function () {
-    setDocsCheckbox();
-    setMsdnCheckbox();
+    setLearnCheckbox();
     setSupportCheckbox();
     setAzureCheckbox();
 
-    $("#docs").change(function () {
+    $("#learn").change(function () {
         if ($(this).is(':checked')) {
-            saveDocsValue(true);
+            saveLearnValue(true);
         } else {
-            saveDocsValue(false);
-        }
-    });
-    $("#msdn").change(function () {
-        if ($(this).is(':checked')) {
-            saveMsdnValue(true);
-        } else {
-            saveMsdnValue(false);
+            saveLearnValue(false);
         }
     });
     $("#support").change(function () {
@@ -36,22 +28,12 @@ $(function () {
     });
 });
 
-function setDocsCheckbox() {
-    chrome.storage.sync.get("docs", function (items) {
-        if (items.docs === false) {
-            $("#docs").prop('checked', false);
+function setLearnCheckbox() {
+    chrome.storage.sync.get("learn", function (items) {
+        if (items.learn === false) {
+            $("#learn").prop('checked', false);
         } else {
-            $("#docs").prop('checked', true);
-        }
-    });
-}
-
-function setMsdnCheckbox() {
-    chrome.storage.sync.get("msdn", function (items) {
-        if (items.msdn === false) {
-            $("#msdn").prop('checked', false);
-        } else {
-            $("#msdn").prop('checked', true);
+            $("#learn").prop('checked', true);
         }
     });
 }
@@ -76,12 +58,8 @@ function setAzureCheckbox() {
     });
 }
 
-function saveDocsValue(value) {
-    chrome.storage.sync.set({'docs': value});
-}
-
-function saveMsdnValue(value) {
-    chrome.storage.sync.set({'msdn': value});
+function saveLearnValue(value) {
+    chrome.storage.sync.set({'learn': value});
 }
 
 function saveSupportValue(value) {

--- a/redirectToEnUs.js
+++ b/redirectToEnUs.js
@@ -1,25 +1,18 @@
 "use strict";
 
-var msdnDomain = "*://msdn.microsoft.com/*";
-var msdnSubdomain = "*://*.msdn.microsoft.com/*";
-var docsDomain = "*://docs.microsoft.com/*";
-var docsSubdomain = "*://*.docs.microsoft.com/*";
+var learnDomain = "*://learn.microsoft.com/*";
+var learnSubdomain = "*://*.learn.microsoft.com/*";
 var supportDomain = "*://support.microsoft.com/*";
 var supportSubdomain = "*://*.support.microsoft.com/*";
 var azureDomain = "*://azure.microsoft.com/*";
 var azureSubdomain = "*://*.azure.microsoft.com/*";
 
 //// Decoded and Encoded URLs
-// msdn
-var decodedEnUsMsdnBaseUrl = "msdn.microsoft.com/en-us";
-var encodedEnUsMsdnBaseUrl = encodeURIComponent(decodedEnUsMsdnBaseUrl);
-var decodedMsdnBaseUrl = "msdn.microsoft.com/";
-var encodedMsdnBaseUrl = encodeURIComponent(decodedMsdnBaseUrl);
-// docs.microsoft
-var decodedEnUsDocsBaseUrl = "docs.microsoft.com/en-us";
-var encodedEnUsDocsBaseUrl = encodeURIComponent(decodedEnUsDocsBaseUrl);
-var decodedDocsBaseUrl = "docs.microsoft.com/";
-var encodedDocsBaseUrl = encodeURIComponent(decodedDocsBaseUrl);
+// learn.microsoft
+var decodedEnUsLearnBaseUrl = "learn.microsoft.com/en-us";
+var encodedEnUsLearnBaseUrl = encodeURIComponent(decodedEnUsLearnBaseUrl);
+var decodedLearnBaseUrl = "learn.microsoft.com/";
+var encodedLearnBaseUrl = encodeURIComponent(decodedLearnBaseUrl);
 // support.microsoft
 var decodedEnUsSupportBaseUrl = "support.microsoft.com/en-us";
 var encodedEnUsSupportBaseUrl = encodeURIComponent(decodedEnUsSupportBaseUrl);
@@ -32,12 +25,9 @@ var decodedAzureBaseUrl = "azure.microsoft.com/";
 var encodedAzureBaseUrl = encodeURIComponent(decodedAzureBaseUrl);
 
 //// Regular Expressions and Patterns
-// msdn
-var msdnPattern = encodedMsdnBaseUrl + "\\D{2}-\\D{2}";
-var msdnRegEx = new RegExp(msdnPattern, "i");
-// docs.microsoft
-var docsPattern = encodedDocsBaseUrl + "\\D{2}-\\D{2}";
-var docsRegEx = new RegExp(docsPattern, "i");
+// learn.microsoft
+var learnPattern = encodedLearnBaseUrl + "\\D{2}-\\D{2}";
+var learnRegEx = new RegExp(learnPattern, "i");
 // support.microsoft
 var supportPattern = encodedSupportBaseUrl + "\\D{2}-\\D{2}";
 var supportRegEx = new RegExp(supportPattern, "i");
@@ -45,24 +35,16 @@ var supportRegEx = new RegExp(supportPattern, "i");
 var azurePattern = encodedAzureBaseUrl + "\\D{2}-\\D{2}";
 var azureRegEx = new RegExp(azurePattern, "i");
 
-var shouldRedirectDocs;
+var shouldRedirectLearn;
 var shouldRedirectMsdn;
 var shouldRedirectSupport;
 var shouldRedirectAzure;
 
-chrome.storage.sync.get("msdn", function (items) {
-    if (items.msdn === false) {
-        shouldRedirectMsdn = false;
+chrome.storage.sync.get("learn", function (items) {
+    if (items.learn === false) {
+        shouldRedirectLearn = false;
     } else {
-        shouldRedirectMsdn = true;
-    }
-});
-
-chrome.storage.sync.get("docs", function (items) {
-    if (items.docs === false) {
-        shouldRedirectDocs = false;
-    } else {
-        shouldRedirectDocs = true;
+        shouldRedirectLearn = true;
     }
 });
 
@@ -89,26 +71,14 @@ function redirect(requestDetails) {
         return;
     }
 
-    // Redirect MSDN
-    if (shouldRedirectMsdn && browserUrl_encoded.match(msdnRegEx)) {
+    // Redirect learn.microsoft
+    if (shouldRedirectLearn && browserUrl_encoded.match(learnRegEx)) {
         // Already in en-us?
-        if (browserUrl_encoded.includes(encodedEnUsMsdnBaseUrl)) {
+        if (browserUrl_encoded.includes(encodedEnUsLearnBaseUrl)) {
             return;
         }
 
-        browserUrl_encoded = browserUrl_encoded.replace(msdnRegEx, encodedEnUsMsdnBaseUrl);
-        var browserUrl_decoded = decodeURIComponent(browserUrl_encoded);
-
-        return {redirectUrl: browserUrl_decoded};
-    }
-    // Redirect docs.microsoft
-    if (shouldRedirectDocs && browserUrl_encoded.match(docsRegEx)) {
-        // Already in en-us?
-        if (browserUrl_encoded.includes(encodedEnUsDocsBaseUrl)) {
-            return;
-        }
-
-        browserUrl_encoded = browserUrl_encoded.replace(docsRegEx, encodedEnUsDocsBaseUrl);
+        browserUrl_encoded = browserUrl_encoded.replace(learnRegEx, encodedEnUsLearnBaseUrl);
         var browserUrl_decoded = decodeURIComponent(browserUrl_encoded);
 
         return {redirectUrl: browserUrl_decoded};
@@ -141,19 +111,15 @@ function redirect(requestDetails) {
 
 chrome.webRequest.onBeforeRequest.addListener(
     redirect,
-    {urls: [msdnDomain, msdnSubdomain,
-            docsDomain, docsSubdomain,
+    {urls: [learnDomain, learnSubdomain,
             supportDomain, supportSubdomain,
             azureDomain, azureSubdomain]},
     ["blocking"]
 );
 
 chrome.storage.onChanged.addListener(function (changes, namespace) {
-    if (changes.docs !== undefined) {
-        shouldRedirectDocs = changes.docs.newValue;
-    }
-    if (changes.msdn !== undefined) {
-        shouldRedirectMsdn = changes.msdn.newValue;
+    if (changes.learn !== undefined) {
+        shouldRedirectLearn = changes.docs.newValue;
     }
     if (changes.support !== undefined) {
         shouldRedirectSupport = changes.support.newValue;


### PR DESCRIPTION
Make learn.microsoft.com available. Removed docs.microsoft.com and MSDN as those are no longer required.

Validated with Firefox 104.0.2